### PR TITLE
Add `:iex` to application()

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule AssertValue.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [],
+      applications: [:iex],
       mod: {AssertValue.App, []}
     ]
   end


### PR DESCRIPTION
This fixes this warning when compiling assert_value:

```
warning: IEx.Info.info/1 defined in application :iex is used by the current application but the current application does not directly depend on :iex. To fix this, you must do one of:

  1. If :iex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :iex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :iex, you may optionally skip this warning by adding [xref: [exclude: IEx.Info]] to your "def project" in mix.exs

  lib/assert_value.ex:185: AssertValue.get_value_type/1
```