### PR TITLE
Deprecated worker

### DIFF
--- a/lib/assert_value/app.ex
+++ b/lib/assert_value/app.ex
@@ -1,5 +1,6 @@
 defmodule AssertValue.App do
   use Application
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
     # We use custom formatter to temporarily capture and
@@ -7,9 +8,11 @@ defmodule AssertValue.App do
     # Config.persist is used because we may not have ExUnit
     # config initialized before this application start.
     Mix.Config.persist(ex_unit: [formatters: [AssertValue.ExUnitFormatter]])
+
     children = [
       worker(AssertValue.Server, [], restart: :temporary)
     ]
+
     opts = [strategy: :one_for_one]
     Supervisor.start_link(children, opts)
   end

--- a/lib/assert_value/app.ex
+++ b/lib/assert_value/app.ex
@@ -10,7 +10,7 @@ defmodule AssertValue.App do
     Mix.Config.persist(ex_unit: [formatters: [AssertValue.ExUnitFormatter]])
 
     children = [
-      worker(AssertValue.Server, [], restart: :temporary)
+      AssertValue.Server
     ]
 
     opts = [strategy: :one_for_one]

--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -1,5 +1,4 @@
 defmodule AssertValue.Server do
-
   use GenServer
   import AssertValue.StringTools
 
@@ -12,42 +11,53 @@ defmodule AssertValue.Server do
     env_settings = System.get_env(env_var_name)
     # Clear environment variable for child processes
     System.delete_env(env_var_name)
-    recurring_answer = cond do
-      env_settings == "y" ->
-        "Y"
-      env_settings == "n" ->
-        "N"
-      env_settings == "reformat" ->
-        # Store this recurring_answer as atom to make it impossible
-        # for user to enter it on asking about diff
-        :reformat
-      env_settings == "ask" ->
-        nil
-      # ASSERT_VALUE_ACCEPT_DIFFS is set to unknown value
-      is_binary(env_settings) ->
-        raise """
-        Unknown ASSERT_VALUE_ACCEPT_DIFFS env variable value "#{env_settings}"
-        Should be one of [y,n,ask,reformat]
-        """
-      # Check that we are running in continuous integration environment
-      # TravisCI and CircleCI have this variable
-      System.get_env("CI") == "true" ->
-        "N"
-      # Elixir sets ansi_enabled env variable on start based on
-      # "/usr/bin/test -t 1 -a -t 2"
-      # This checks that STDOUT and STERR are terminals. If so we
-      # can prompt user for answers.
-      IO.ANSI.enabled? ->
-        nil
-      true ->
-        "N"
-    end
+
+    recurring_answer =
+      cond do
+        env_settings == "y" ->
+          "Y"
+
+        env_settings == "n" ->
+          "N"
+
+        env_settings == "reformat" ->
+          # Store this recurring_answer as atom to make it impossible
+          # for user to enter it on asking about diff
+          :reformat
+
+        env_settings == "ask" ->
+          nil
+
+        # ASSERT_VALUE_ACCEPT_DIFFS is set to unknown value
+        is_binary(env_settings) ->
+          raise """
+          Unknown ASSERT_VALUE_ACCEPT_DIFFS env variable value "#{env_settings}"
+          Should be one of [y,n,ask,reformat]
+          """
+
+        # Check that we are running in continuous integration environment
+        # TravisCI and CircleCI have this variable
+        System.get_env("CI") == "true" ->
+          "N"
+
+        # Elixir sets ansi_enabled env variable on start based on
+        # "/usr/bin/test -t 1 -a -t 2"
+        # This checks that STDOUT and STERR are terminals. If so we
+        # can prompt user for answers.
+        IO.ANSI.enabled?() ->
+          nil
+
+        true ->
+          "N"
+      end
+
     state = %{
       captured_ex_unit_io_pid: nil,
       file_changes: %{},
       recurring_answer: recurring_answer,
       formatter_options: read_dot_formatter()
     }
+
     {:ok, state}
   end
 
@@ -57,7 +67,7 @@ defmodule AssertValue.Server do
 
   def handle_cast({:flush_ex_unit_io}, state) do
     contents = StringIO.flush(state.captured_ex_unit_io_pid)
-    if contents != "", do: IO.write contents
+    if contents != "", do: IO.write(contents)
     {:noreply, state}
   end
 
@@ -72,11 +82,12 @@ defmodule AssertValue.Server do
     # TODO: Refactor to messaging
     Process.sleep(30)
     contents = StringIO.flush(state.captured_ex_unit_io_pid)
-    if contents != "", do: IO.write contents
+    if contents != "", do: IO.write(contents)
 
     case prepare_formatted_diff_and_new_code(opts, state) do
       {:ok, prepared} ->
         {answer, state} = prompt_for_action(prepared.diff, opts, state)
+
         if answer in ["y", "Y", :reformat] do
           file_changes =
             if opts[:expected_type] == :file do
@@ -84,6 +95,7 @@ defmodule AssertValue.Server do
               state.file_changes
             else
               File.write!(opts[:caller][:file], prepared.new_file_content)
+
               update_line_numbers(
                 state.file_changes,
                 opts[:caller][:file],
@@ -92,89 +104,104 @@ defmodule AssertValue.Server do
                 prepared.new_assert_value
               )
             end
+
           {:reply, :ok, %{state | file_changes: file_changes}}
         else
           # Fail test. Pass exception up to the caller and throw it there
-          {:reply,  {:error, :ex_unit_assertion_error, [
+          {:reply,
+           {:error, :ex_unit_assertion_error,
+            [
               left: opts[:actual_value],
               right: opts[:expected_value],
               expr: Macro.to_string(opts[:assertion_ast]),
               message: "AssertValue assertion failed"
-          ]},
-          state}
+            ]}, state}
         end
+
       {:error, :parse_error} ->
         {:reply, {:error, :parse_error}, state}
     end
   end
 
   def set_captured_ex_unit_io_pid(pid) do
-    GenServer.cast __MODULE__, {:set_captured_ex_unit_io_pid, pid}
+    GenServer.cast(__MODULE__, {:set_captured_ex_unit_io_pid, pid})
   end
 
   def flush_ex_unit_io do
-    GenServer.cast __MODULE__, {:flush_ex_unit_io}
+    GenServer.cast(__MODULE__, {:flush_ex_unit_io})
   end
 
   # All calls get :infinity timeout because GenServer may wait for user input
 
   def reformat_expected? do
-    GenServer.call __MODULE__, {:reformat_expected?}, :infinity
+    GenServer.call(__MODULE__, {:reformat_expected?}, :infinity)
   end
 
   def ask_user_about_diff(opts) do
-    GenServer.call __MODULE__, {:ask_user_about_diff, opts}, :infinity
+    GenServer.call(__MODULE__, {:ask_user_about_diff, opts}, :infinity)
   end
 
   defp prepare_formatted_diff_and_new_code(opts, state) do
     if opts[:expected_type] == :file do
-      {:ok, %{
-        diff: AssertValue.Diff.diff(opts[:expected_value], opts[:actual_value])
-      }}
+      {:ok,
+       %{
+         diff: AssertValue.Diff.diff(opts[:expected_value], opts[:actual_value])
+       }}
     else
-      current_line_number = current_line_number(
-        state.file_changes,
-        opts[:caller][:file],
-        opts[:caller][:line]
-      )
+      current_line_number =
+        current_line_number(
+          state.file_changes,
+          opts[:caller][:file],
+          opts[:caller][:line]
+        )
+
       case AssertValue.Parser.parse_assert_value(
-        opts[:caller][:file],
-        current_line_number,
-        opts[:assertion_ast],
-        opts[:actual_ast],
-        opts[:expected_ast]
-      ) do
+             opts[:caller][:file],
+             current_line_number,
+             opts[:assertion_ast],
+             opts[:actual_ast],
+             opts[:expected_ast]
+           ) do
         {:ok, parsed} ->
-           new_expected = AssertValue.Formatter.new_expected_from_actual_value(
-            opts[:actual_value]
-          )
+          new_expected =
+            AssertValue.Formatter.new_expected_from_actual_value(
+              opts[:actual_value]
+            )
 
           new_assert_value =
             parsed.assert_value_prefix <>
-            new_expected <>
-            parsed.assert_value_suffix
+              new_expected <>
+              parsed.assert_value_suffix
 
           # Format old assert value with formatter to diff it against
           # new assert_value. This way user will see only expected value
           # diff without mixing it with formatting diff
-          old_assert_value = AssertValue.Formatter.format_with_indentation(
-            parsed.assert_value, parsed.indentation, state.formatter_options
-          )
+          old_assert_value =
+            AssertValue.Formatter.format_with_indentation(
+              parsed.assert_value,
+              parsed.indentation,
+              state.formatter_options
+            )
 
-          new_assert_value = AssertValue.Formatter.format_with_indentation(
-            new_assert_value, parsed.indentation, state.formatter_options
-          )
+          new_assert_value =
+            AssertValue.Formatter.format_with_indentation(
+              new_assert_value,
+              parsed.indentation,
+              state.formatter_options
+            )
 
           diff = AssertValue.Diff.diff(old_assert_value, new_assert_value)
 
           new_file_content = parsed.prefix <> new_assert_value <> parsed.suffix
 
-          {:ok, %{
-            diff: diff,
-            new_file_content: new_file_content,
-            old_assert_value: parsed.assert_value,
-            new_assert_value: new_assert_value
-          }}
+          {:ok,
+           %{
+             diff: diff,
+             new_file_content: new_file_content,
+             old_assert_value: parsed.assert_value,
+             new_assert_value: new_assert_value
+           }}
+
         {:error, :parse_error} ->
           {:error, :parse_error}
       end
@@ -193,7 +220,9 @@ defmodule AssertValue.Server do
   defp print_diff_and_context(diff, opts) do
     file =
       opts[:caller][:file]
-      |> Path.relative_to(File.cwd!) # make it shorter
+      # make it shorter
+      |> Path.relative_to(File.cwd!())
+
     line = opts[:caller][:line]
     # the prompt we print here should
     # * let user easily identify which assert failed
@@ -202,39 +231,44 @@ defmodule AssertValue.Server do
     # * not be unreasonably long, so the user sees it on the screen
     #   grouped with the diff
     {function, _} = opts[:caller][:function]
+    # We don't need to print context when showing diff for assert_value
+    # statement because all context is in diff. But we still need to print
+    # context when showing diff for File.read! Because we show only diff
+    # for file contents in that case.
     diff_context =
-      # We don't need to print context when showing diff for assert_value
-      # statement because all context is in diff. But we still need to print
-      # context when showing diff for File.read! Because we show only diff
-      # for file contents in that case.
       if opts[:expected_type] == :file do
-        code = opts[:assertion_ast] |> Macro.to_string |> smart_truncate(40)
+        code = opts[:assertion_ast] |> Macro.to_string() |> smart_truncate(40)
         "#{file}:#{line}:\"#{function}\" assert_value #{code} failed"
       else
         "#{file}:#{line}:\"#{function}\" assert_value failed"
       end
+
     diff_lines_count = String.split(diff, "\n") |> Enum.count()
-    IO.puts "\n" <> diff_context <> "\n"
-    IO.puts diff
+    IO.puts("\n" <> diff_context <> "\n")
+    IO.puts(diff)
     # If diff is too long diff context does not fit to screen
     # we need to repeat it
-    if diff_lines_count > 37, do: IO.puts diff_context
+    if diff_lines_count > 37, do: IO.puts(diff_context)
   end
 
   defp get_answer(diff, opts, state) do
     answer =
       IO.gets("Accept new value? [y,n,?] ")
       |> String.trim_trailing("\n")
+
     case answer do
       "?" ->
         print_help()
         get_answer(diff, opts, state)
+
       "d" ->
         print_diff_and_context(diff, opts)
         get_answer(diff, opts, state)
-      c when c in ["Y", "N"]  ->
+
+      c when c in ["Y", "N"] ->
         # Save answer in state and use it in future
         {c, %{state | recurring_answer: c}}
+
       _ ->
         {answer, state}
     end
@@ -250,28 +284,37 @@ defmodule AssertValue.Server do
     d - Show diff between actual and expected values
     ? - This help
     """
-    |> String.replace(~r/^/m, "    ") # Indent all lines
-    |> IO.puts
+    # Indent all lines
+    |> String.replace(~r/^/m, "    ")
+    |> IO.puts()
   end
 
   # Helpers to keep changes we make to files on updating expected values
 
   def current_line_number(file_changes, filename, original_line_number) do
     current_file_changes = file_changes[filename] || %{}
-    cumulative_offset = Enum.reduce(current_file_changes, 0,
-      fn({l, o}, total) ->
+
+    cumulative_offset =
+      Enum.reduce(current_file_changes, 0, fn {l, o}, total ->
         if original_line_number > l, do: total + o, else: total
       end)
+
     original_line_number + cumulative_offset
   end
 
   def update_line_numbers(
-    file_changes, filename, original_line_number, old_expected, new_expected
-  ) do
+        file_changes,
+        filename,
+        original_line_number,
+        old_expected,
+        new_expected
+      ) do
     offset = length(to_lines(new_expected)) - length(to_lines(old_expected))
+
     current_file_changes =
       (file_changes[filename] || %{})
       |> Map.put(original_line_number, offset)
+
     Map.put(file_changes, filename, current_file_changes)
   end
 
@@ -294,22 +337,22 @@ defmodule AssertValue.Server do
 
         opts
       else
-        [] # Use default Elixir formatter options
+        # Use default Elixir formatter options
+        []
       end
 
     # Force locals_without_parens for assert_value. We don't eval
     # formatter options from all user dependencies (including assert_value).
     # Also user may not add "import_deps: [:assert_value]" to .formatter.exs
-    forced_options = MapSet.new([assert_value: :*])
+    forced_options = MapSet.new(assert_value: :*)
 
     locals_without_parens =
-        opts
-        |> Keyword.get(:locals_without_parens, [])
-        |> MapSet.new()
-        |> MapSet.union(forced_options)
-        |> MapSet.to_list()
+      opts
+      |> Keyword.get(:locals_without_parens, [])
+      |> MapSet.new()
+      |> MapSet.union(forced_options)
+      |> MapSet.to_list()
 
     Keyword.put(opts, :locals_without_parens, locals_without_parens)
   end
-
 end

--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -1,9 +1,9 @@
 defmodule AssertValue.Server do
-  use GenServer
+  use GenServer, restart: :temporary
   import AssertValue.StringTools
 
-  def start_link do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
   def init(_) do


### PR DESCRIPTION
This fix the following deprecation warning when compiling.

```
warning: Supervisor.Spec.worker/3 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/assert_value/app.ex:11: AssertValue.App.start/2
```

I have my editor setup to run mix format on save for the edited file. This causes the diff for this PR to be more drastic than it otherwise would be. I committed these formatter changes as a separate commit to make review easier and so that it can be dropped, if need be.