### PR TITLE
Update credo

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule AssertValue.Mixfile do
   defp deps do
     [
       {:temp, "~> 0.4", only: :test, runtime: false},
-      {:credo, "~> 0.10", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.4.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/test/bad_arguments_test.exs
+++ b/test/bad_arguments_test.exs
@@ -190,11 +190,11 @@ defmodule AssertValue.BadArgumentsTest do
       end)
 
       # Also emits warning
-      # credo:disable-for-lines:2 Credo.Check.Readability.MaxLineLength
+      # credo:disable-for-lines:5 Credo.Check.Readability.MaxLineLength
       assert_value stderr_output == """
       \e[33mwarning: \e[0mvariable \"...\" does not exist and is being expanded to \"...()\", please use parentheses to remove the ambiguity or change the variable name
         nofile:1
-      
+
       """
 
     end
@@ -221,11 +221,11 @@ defmodule AssertValue.BadArgumentsTest do
       end)
 
       # Also emits warning
-      # credo:disable-for-lines:2 Credo.Check.Readability.MaxLineLength
+      # credo:disable-for-lines:5 Credo.Check.Readability.MaxLineLength
       assert_value stderr_output == """
       \e[33mwarning: \e[0mvariable \"...\" does not exist and is being expanded to \"...()\", please use parentheses to remove the ambiguity or change the variable name
         nofile:1
-      
+
       """
     end
   end


### PR DESCRIPTION
Bumps credo to 1.4 and fixes a small `credo:disable` comment behavior change. This fixes a number of compilation warnings for credo when compiling assert_value.

Note: Credo 1.5 will drop support for Elixir 1.6.