### PR TITLE
Fix arguments parsing in Elixir 1.16

### DIFF
--- a/lib/assert_value/parser.ex
+++ b/lib/assert_value/parser.ex
@@ -196,7 +196,7 @@ defmodule AssertValue.Parser do
   # iex> remove_ast_meta({:foo, [line: 10, counter: 6], []})
   # {:foo, [], []}
   defp remove_ast_meta(ast) do
-    cleaner = &Keyword.drop(&1, [:line, :counter])
+    cleaner = &Keyword.drop(&1, [:line, :column, :counter])
     Macro.prewalk(ast, &Macro.update_meta(&1, cleaner))
   end
 


### PR DESCRIPTION
This is a small fix that I've encountered with parsing assertions in case they were not matching. Instead of showing you a diff with y/n prompt, you'd get `** (AssertValue.Parser.ParseError) Unable to parse assert_value arguments`.

I'm not sure if there will be a bigger PR/update to fix all potential issues with Elixir 1.16, but I'm opening this just for visibility.