### PR TITLE
POC: Add context to assert_value

### DIFF
--- a/lib/assert_value.ex
+++ b/lib/assert_value.ex
@@ -1,4 +1,5 @@
 defmodule AssertValue do
+  require AssertValue
   # Assertions with right argument like "assert_value actual == expected"
   defmacro assert_value({:==, _, [left, right]} = assertion) do
     {expected_type, expected_file} =
@@ -113,6 +114,15 @@ defmodule AssertValue do
           # to show readable error message and stacktrace
           raise AssertValue.Parser.ParseError
       end
+    end
+  end
+
+  defmacro assert_value(
+             {:==, _, [_, _]} = assertion,
+             with_context: context
+           ) do
+    quote do
+      assert_value(unquote(assertion), with_context: unquote(context), context: unquote(context))
     end
   end
 

--- a/lib/assert_value.ex
+++ b/lib/assert_value.ex
@@ -2,118 +2,8 @@ defmodule AssertValue do
   require AssertValue
   # Assertions with right argument like "assert_value actual == expected"
   defmacro assert_value({:==, _, [left, right]} = assertion) do
-    {expected_type, expected_file} =
-      case right do
-        {{:., _, [{:__aliases__, _, [:File]}, :read!]}, _, [filename]} ->
-          {:file, filename}
-
-        str when is_binary(str) ->
-          {:string, nil}
-
-        _ ->
-          {:other, nil}
-      end
-
     quote do
-      assertion_ast = unquote(Macro.escape(assertion))
-      actual_ast = unquote(Macro.escape(left))
-      actual_value = unquote(left)
-      expected_type = unquote(expected_type)
-      expected_file = unquote(expected_file)
-      expected_ast = unquote(Macro.escape(right))
-
-      expected_value =
-        case expected_type do
-          :string ->
-            unquote(right)
-            |> String.replace(~r/<NOEOL>\n\Z/, "", global: false)
-
-          # TODO: should deal with a no-bang File.read instead, may
-          # want to deal with different errors differently
-          :file ->
-            (File.exists?(expected_file) &&
-               File.read!(expected_file)) ||
-              ""
-
-          :other ->
-            unquote(right)
-        end
-
-      check_serializable(actual_value)
-      check_string_and_file_read(actual_value, expected_type)
-      # We need to check for reformat_expected? first to disable
-      # "this check/guard will always yield the same result" warnings
-      if AssertValue.Server.reformat_expected?() ||
-           actual_value != expected_value do
-        decision =
-          AssertValue.Server.ask_user_about_diff(
-            caller: [
-              file: unquote(__CALLER__.file),
-              line: unquote(__CALLER__.line),
-              function: unquote(__CALLER__.function)
-            ],
-            assertion_ast: assertion_ast,
-            actual_ast: actual_ast,
-            actual_value: actual_value,
-            expected_type: expected_type,
-            expected_ast: expected_ast,
-            expected_value: expected_value,
-            expected_file: expected_file
-          )
-
-        case decision do
-          :ok ->
-            true
-
-          {:error, :ex_unit_assertion_error, error_attrs} ->
-            raise ExUnit.AssertionError, error_attrs
-
-          {:error, :parse_error} ->
-            # raise ParseError in test instead of genserver
-            # to show readable error message and stacktrace
-            raise AssertValue.Parser.ParseError
-        end
-      else
-        true
-      end
-    end
-  end
-
-  # Assertions without right argument like (assert_value "foo")
-  defmacro assert_value(assertion) do
-    quote do
-      assertion_ast = unquote(Macro.escape(assertion))
-      actual_value = unquote(assertion)
-      check_serializable(actual_value)
-
-      decision =
-        AssertValue.Server.ask_user_about_diff(
-          caller: [
-            file: unquote(__CALLER__.file),
-            line: unquote(__CALLER__.line),
-            function: unquote(__CALLER__.function)
-          ],
-          assertion_ast: assertion_ast,
-          # :_not_present_ is to show the difference between
-          # nil and actually not present actual/expected
-          actual_ast: :_not_present_,
-          actual_value: actual_value,
-          expected_type: :source,
-          expected_ast: :_not_present_
-        )
-
-      case decision do
-        :ok ->
-          true
-
-        {:error, :ex_unit_assertion_error, error_attrs} ->
-          raise ExUnit.AssertionError, error_attrs
-
-        {:error, :parse_error} ->
-          # raise ParseError in test instead of genserver
-          # to show readable error message and stacktrace
-          raise AssertValue.Parser.ParseError
-      end
+      assert_value(unquote(assertion), with_context: :_not_present, context: :_not_present)
     end
   end
 
@@ -205,6 +95,44 @@ defmodule AssertValue do
         end
       else
         true
+      end
+    end
+  end
+
+  # Assertions without right argument like (assert_value "foo")
+  defmacro assert_value(assertion) do
+    quote do
+      assertion_ast = unquote(Macro.escape(assertion))
+      actual_value = unquote(assertion)
+      check_serializable(actual_value)
+
+      decision =
+        AssertValue.Server.ask_user_about_diff(
+          caller: [
+            file: unquote(__CALLER__.file),
+            line: unquote(__CALLER__.line),
+            function: unquote(__CALLER__.function)
+          ],
+          assertion_ast: assertion_ast,
+          # :_not_present_ is to show the difference between
+          # nil and actually not present actual/expected
+          actual_ast: :_not_present_,
+          actual_value: actual_value,
+          expected_type: :source,
+          expected_ast: :_not_present_
+        )
+
+      case decision do
+        :ok ->
+          true
+
+        {:error, :ex_unit_assertion_error, error_attrs} ->
+          raise ExUnit.AssertionError, error_attrs
+
+        {:error, :parse_error} ->
+          # raise ParseError in test instead of genserver
+          # to show readable error message and stacktrace
+          raise AssertValue.Parser.ParseError
       end
     end
   end

--- a/lib/assert_value.ex
+++ b/lib/assert_value.ex
@@ -118,7 +118,8 @@ defmodule AssertValue do
 
   defmacro assert_value(
              {:==, _, [left, right]} = assertion,
-             with_context: context
+             with_context: context,
+             context: _context
            ) do
     {expected_type, expected_file} =
       case right do

--- a/lib/assert_value.ex
+++ b/lib/assert_value.ex
@@ -116,6 +116,88 @@ defmodule AssertValue do
     end
   end
 
+  defmacro assert_value(
+             {:==, _, [left, right]} = assertion,
+             with_context: context
+           ) do
+    {expected_type, expected_file} =
+      case right do
+        {{:., _, [{:__aliases__, _, [:File]}, :read!]}, _, [filename]} ->
+          {:file, filename}
+
+        str when is_binary(str) ->
+          {:string, nil}
+
+        _ ->
+          {:other, nil}
+      end
+
+    quote do
+      assertion_ast = unquote(Macro.escape(assertion))
+      actual_ast = unquote(Macro.escape(left))
+      actual_value = unquote(left)
+      expected_type = unquote(expected_type)
+      expected_file = unquote(expected_file)
+      expected_ast = unquote(Macro.escape(right))
+
+      expected_value =
+        case expected_type do
+          :string ->
+            unquote(right)
+            |> String.replace(~r/<NOEOL>\n\Z/, "", global: false)
+
+          # TODO: should deal with a no-bang File.read instead, may
+          # want to deal with different errors differently
+          :file ->
+            (File.exists?(expected_file) &&
+               File.read!(expected_file)) ||
+              ""
+
+          :other ->
+            unquote(right)
+        end
+
+      check_serializable(actual_value)
+      check_string_and_file_read(actual_value, expected_type)
+      same = actual_value == expected_value
+      # We need to check for reformat_expected? first to disable
+      # "this check/guard will always yield the same result" warnings
+      if AssertValue.Server.reformat_expected?() || not same do
+        decision =
+          AssertValue.Server.ask_user_about_diff(
+            caller: [
+              file: unquote(__CALLER__.file),
+              line: unquote(__CALLER__.line),
+              function: unquote(__CALLER__.function)
+            ],
+            assertion_ast: assertion_ast,
+            actual_ast: actual_ast,
+            actual_value: actual_value,
+            expected_type: expected_type,
+            expected_ast: expected_ast,
+            expected_value: expected_value,
+            expected_file: expected_file,
+            context: unquote(context)
+          )
+
+        case decision do
+          :ok ->
+            true
+
+          {:error, :ex_unit_assertion_error, error_attrs} ->
+            raise ExUnit.AssertionError, error_attrs
+
+          {:error, :parse_error} ->
+            # raise ParseError in test instead of genserver
+            # to show readable error message and stacktrace
+            raise AssertValue.Parser.ParseError
+        end
+      else
+        true
+      end
+    end
+  end
+
   defmodule ArgumentError do
     defexception [:message]
   end

--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -169,17 +169,34 @@ defmodule AssertValue.Server do
                     assertion_lhs,
                     {_, assertion_rhs_meta, [assertion_rhs_value]}
                   ]},
-                 [
-                   {{:__block__, with_context_meta, [:with_context]},
-                    with_context_meta_value_meta},
-                   {{:__block__, context_meta, [:context]},
-                    {:__block__, context_value_meta, [_context]}}
-                 ]
+                 context_args
                ]} ->
             assert_value_meta_line_nr = Keyword.get(assert_value_meta, :line)
 
             if assert_value_meta_line_nr === line_nr do
+              {with_context_meta, with_context_meta_value_meta, context_meta, context_value_meta} =
+                case context_args do
+                  [
+                    {{:__block__, with_context_meta, [:with_context]},
+                     with_context_meta_value_meta},
+                    {{:__block__, context_meta, [:context]},
+                     {:__block__, context_value_meta, [_context]}}
+                  ] ->
+                    {with_context_meta, with_context_meta_value_meta, context_meta,
+                     context_value_meta}
+
+                  [
+                    {{:__block__, with_context_meta, [:with_context]},
+                     with_context_meta_value_meta}
+                  ] ->
+                    {with_context_meta, with_context_meta_value_meta,
+                     [format: :keyword, line: assert_value_meta_line_nr + 2], []}
+                end
+
               context_value = opts[:context]
+
+              IO.inspect(context_meta, label: "context_meta")
+              IO.inspect(context_value_meta, label: "context_value_meta")
 
               context_value_meta =
                 if length(to_lines(context_value)) > 1 do
@@ -200,7 +217,7 @@ defmodule AssertValue.Server do
                    {{:__block__, with_context_meta, [:with_context]},
                     with_context_meta_value_meta},
                    {{:__block__, context_meta, [:context]},
-                    {:__block__, context_value_meta, [opts[:context]]}}
+                    {:__block__, context_value_meta, [context_value]}}
                  ]
                ]}
             else

--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -161,16 +161,38 @@ defmodule AssertValue.Server do
       f_str =
         f_ast
         |> Macro.postwalk(fn
-          quoted =
+          {:assert_value, assert_value_meta,
+           [
+             {:==, assertion_meta,
+              [
+                assertion_lhs,
+                {a, assertion_rhs_meta, [_assertion_rhs_value]}
+              ]}
+           ]} = quoted ->
+            assert_value_meta_line_nr = Keyword.get(assert_value_meta, :line)
+
+            if assert_value_meta_line_nr === line_nr do
               {:assert_value, assert_value_meta,
                [
                  {:==, assertion_meta,
                   [
                     assertion_lhs,
-                    {_, assertion_rhs_meta, [assertion_rhs_value]}
-                  ]},
-                 context_args
-               ]} ->
+                    {a, assertion_rhs_meta, [actual_ast_sourceror]}
+                  ]}
+               ]}
+            else
+              quoted
+            end
+
+          {:assert_value, assert_value_meta,
+           [
+             {:==, assertion_meta,
+              [
+                assertion_lhs,
+                {_, assertion_rhs_meta, [assertion_rhs_value]}
+              ]},
+             context_args
+           ]} = quoted ->
             assert_value_meta_line_nr = Keyword.get(assert_value_meta, :line)
 
             if assert_value_meta_line_nr === line_nr do

--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -164,10 +164,7 @@ defmodule AssertValue.Server do
         {:ok, parsed} ->
           formatter_options = formatter_options_for_file(opts[:caller][:file])
 
-          new_expected =
-            AssertValue.Formatter.new_expected_from_actual_value(
-              opts[:actual_value]
-            )
+          new_expected = AssertValue.Formatter.new_expected_from_actual_value(opts[:actual_value])
 
           new_assert_value =
             parsed.assert_value_prefix <>
@@ -244,12 +241,26 @@ defmodule AssertValue.Server do
         "#{file}:#{line}:\"#{function}\" assert_value failed"
       end
 
+    all_context =
+      case Keyword.fetch(opts, :context) do
+        {:ok, context} ->
+          """
+          #{diff_context}
+
+          = Context =
+          #{context}
+          """
+
+        _ ->
+          diff_context
+      end
+
     diff_lines_count = String.split(diff, "\n") |> Enum.count()
-    IO.puts("\n" <> diff_context <> "\n")
+    IO.puts("\n" <> all_context <> "\n")
     IO.puts(diff)
     # If diff is too long diff context does not fit to screen
     # we need to repeat it
-    if diff_lines_count > 37, do: IO.puts(diff_context)
+    if diff_lines_count > 37, do: IO.puts(all_context)
   end
 
   defp get_answer(diff, opts, state) do

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule AssertValue.Mixfile do
   defp deps do
     [
       {:credo, "~> 1.7", only: :dev, runtime: false},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:sourceror, "~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
It prints out the context when the values are different. I have made this very WET for now by simply pasting the body of assert_value/1 macro.

The next step would be to update the context inline.

It looks like this currently:

```
test/chatgpt/custom_gpt_test/order_blood_tests/prompt_test.exs:6:"test A" assert_value failed

= Context =
fn_to_get_context

     assert_value "39393eei99393" <> "-------------------------------" ==
-                   "39393ee99393-------------------------------"
+                   "39393eei99393-------------------------------"

Accept new value? [y,n,?]
```

PS: I have had to make strings on long lines because of #16.

