### PR TITLE
fix: fix parsing in Elixir 1.20

### DIFF
--- a/lib/assert_value/parser.ex
+++ b/lib/assert_value/parser.ex
@@ -196,7 +196,9 @@ defmodule AssertValue.Parser do
   # iex> remove_ast_meta({:foo, [line: 10, counter: 6], []})
   # {:foo, [], []}
   defp remove_ast_meta(ast) do
-    cleaner = &Keyword.drop(&1, [:line, :column, :counter, :stop_generated, :generated])
+    cleaner =
+      &Keyword.drop(&1, [:line, :column, :counter, :stop_generated, :generated])
+
     Macro.prewalk(ast, &Macro.update_meta(&1, cleaner))
   end
 

--- a/lib/assert_value/parser.ex
+++ b/lib/assert_value/parser.ex
@@ -196,7 +196,7 @@ defmodule AssertValue.Parser do
   # iex> remove_ast_meta({:foo, [line: 10, counter: 6], []})
   # {:foo, [], []}
   defp remove_ast_meta(ast) do
-    cleaner = &Keyword.drop(&1, [:line, :column, :counter])
+    cleaner = &Keyword.drop(&1, [:line, :column, :counter, :stop_generated, :generated])
     Macro.prewalk(ast, &Macro.update_meta(&1, cleaner))
   end
 


### PR DESCRIPTION
This fix is similar to the one required for Elixir 1.16 https://github.com/assert-value/assert_value_elixir/pull/15.

This problem manifests only during a mismatch of the left and right side and when the asserting value is complex enough. Not sure what "complex enough" means, but simple map assert (`assert_value(%{a: 1} == %{}`) works, but large, nested map does not work.